### PR TITLE
Fixed WaiDaemonsetReady to continue checking if DesiredNumberScheduled is not valid.

### DIFF
--- a/main.go
+++ b/main.go
@@ -218,8 +218,8 @@ func WaitDaemonsetReady(namespace, name string, timeout time.Duration) error {
 				break
 			}
 		} else {
-			logrus.Warnf("daemonset DesiredNumberScheduled %d not equal to number of nodes:%d, please make sure daemonset pods can be deployed on all nodes",
-				daemonSet.Status.DesiredNumberScheduled, nodesCount)
+			logrus.Warnf("Daemonset %s (ns %s) could not be deployed: DesiredNumberSheduled=%d - NodesCount=%d",
+				name, namespace, daemonSet.Status.DesiredNumberScheduled, nodesCount)
 		}
 
 		time.Sleep(waitingTime)

--- a/main.go
+++ b/main.go
@@ -212,13 +212,13 @@ func WaitDaemonsetReady(namespace, name string, timeout time.Duration) error {
 		}
 
 		if daemonSet.Status.DesiredNumberScheduled == nodesCount {
-			logrus.Infof("Waiting for (%d) debug pods to be ready: %+v", nodesCount, daemonSet.Status)
+			logrus.Infof("Waiting for (%d) daemonset pods to be ready: %+v", nodesCount, daemonSet.Status)
 			if isDaemonSetReady(&daemonSet.Status) {
 				isReady = true
 				break
 			}
 		} else {
-			logrus.Warnf("daemonset DesiredNumberScheduled %d not equal to number of nodes:%d, please instantiate debug pods on all nodes",
+			logrus.Warnf("daemonset DesiredNumberScheduled %d not equal to number of nodes:%d, please make sure daemonset pods can be deployed on all nodes",
 				daemonSet.Status.DesiredNumberScheduled, nodesCount)
 		}
 

--- a/main.go
+++ b/main.go
@@ -211,15 +211,17 @@ func WaitDaemonsetReady(namespace, name string, timeout time.Duration) error {
 			return fmt.Errorf("failed to get daemonset, err: %s", err)
 		}
 
-		if daemonSet.Status.DesiredNumberScheduled != nodesCount {
-			return fmt.Errorf("daemonset DesiredNumberScheduled not equal to number of nodes:%d, please instantiate debug pods on all nodes", nodesCount)
+		if daemonSet.Status.DesiredNumberScheduled == nodesCount {
+			logrus.Infof("Waiting for (%d) debug pods to be ready: %+v", nodesCount, daemonSet.Status)
+			if isDaemonSetReady(&daemonSet.Status) {
+				isReady = true
+				break
+			}
+		} else {
+			logrus.Warnf("daemonset DesiredNumberScheduled %d not equal to number of nodes:%d, please instantiate debug pods on all nodes",
+				daemonSet.Status.DesiredNumberScheduled, nodesCount)
 		}
 
-		logrus.Infof("Waiting for (%d) debug pods to be ready: %+v", nodesCount, daemonSet.Status)
-		if isDaemonSetReady(&daemonSet.Status) {
-			isReady = true
-			break
-		}
 		time.Sleep(waitingTime)
 	}
 


### PR DESCRIPTION
In some cases, the daemonset's field DesiredNumberScheduled takes a bit longer to be updated to the right value by k8s, so it remains as 0 for a short period of time. This function has been updated to wait instead of returning an error when the values don't match.

This change is similar to this TNF's one:
https://github.com/test-network-function/cnf-certification-test/pull/253