### PR TITLE
Upgrade Golangci-lint to v1.50.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ else
 endif
 
 # Variables
-GOLANGCI_VERSION=v1.49.0
+GOLANGCI_VERSION=v1.50.0
 
 vet:
 	go vet ${GO_PACKAGES}


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.50.0

Related to: https://github.com/test-network-function/cnf-certification-test/pull/604