### PR TITLE
Update Go to v1.19.5

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.4
+          go-version: 1.19.5
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/wrmRT7JlevE

Related to: https://github.com/test-network-function/cnf-certification-test/pull/779