### PR TITLE
Update Go to 1.19.6

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go 1.19
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.5
+          go-version: 1.19.6
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"


### PR DESCRIPTION
Related to: https://github.com/test-network-function/cnf-certification-test/pull/864

https://groups.google.com/g/golang-announce/c/V0aBFqaFs_E