### PR TITLE
Upgrade Go to v1.20.1

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.6
+          go-version: 1.20.1
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/privileged-daemonset
 
-go 1.19
+go 1.20
 
 require (
 	github.com/sirupsen/logrus v1.9.0


### PR DESCRIPTION
Release Notes: https://tip.golang.org/doc/go1.20

Related to: https://github.com/test-network-function/cnf-certification-test/pull/873