### PR TITLE
Add retract directive for v1.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,3 +45,7 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+retract (
+	v1.0.0 // Throwing errors in dependabot.
+)


### PR DESCRIPTION
https://go.dev/ref/mod#go-mod-file-retract

v1.0.0 continues to be a problem in go mod updates via dependabot and locally.

```
$ go get -u github.com/test-network-function/privileged-daemonset
go: downloading github.com/test-network-function/privileged-daemonset v1.0.0
go: github.com/test-network-function/privileged-daemonset@v1.0.0: verifying module: checksum mismatch
        downloaded: h1:iGSRZ9iX0IiItjj4lNhkkxUwhn8b/ln/gyzDe8E3LlA=
        sum.golang.org: h1:piL5Kx+BkiebhOhvC+F8vk/n8ws7nRsuzx+vSbD6wkU=

SECURITY ERROR
This download does NOT match the one reported by the checksum server.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.

For more information, see 'go help module-auth'.
```