### PR TITLE
add security-context configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -394,10 +394,6 @@ func namespaceIsPresent(namespace string) bool {
 	return true
 }
 
-func namespaceDelete(aNamespace string) error {
-	return daemonsetClient.K8sClient.CoreV1().Namespaces().Delete(context.Background(), aNamespace, metav1.DeleteOptions{})
-}
-
 // WaitForDeletion waits until the namespace will be removed from the cluster
 func namespaceWaitForDeletion(nsName string, timeout time.Duration) error {
 	return wait.PollImmediate(time.Second, timeout, func() (bool, error) {
@@ -430,7 +426,7 @@ func DeleteNamespaceIfPresent(namespace string) (err error) {
 	if !namespaceIsPresent(namespace) {
 		return nil
 	}
-	err = namespaceDelete(namespace)
+	err = daemonsetClient.K8sClient.CoreV1().Namespaces().Delete(context.Background(), namespace, metav1.DeleteOptions{})
 	if err != nil {
 		logrus.Warnf("could not delete namespace=%s, err=%s", namespace, err)
 	}


### PR DESCRIPTION
This is to configure the security context needed by the daemonset. Currently, the user is expected to manually have a special configuration to be able to run it or configure service account, role binding and roles outside of this code. 
The PR is adding the following:
- creating the namespace if needed. The namespace is expected to contain only the daemonset
- creating the service account and associate it with the daemonset's pods
- creating the role binding object
- creating the roles object
With this additional configuration, the daemonset can run on a fresh openshift cluster with no special configuration or knowledge from the user.