### PR TITLE
Fix go directive to include patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/privileged-daemonset
 
-go 1.21
+go 1.21.1
 
 require (
 	github.com/sirupsen/logrus v1.9.3


### PR DESCRIPTION
Similar to: https://github.com/test-network-function/cnf-certification-test/pull/1392